### PR TITLE
add MeetWithParticipants type for getMeet return type

### DIFF
--- a/src/controllers/meet.ts
+++ b/src/controllers/meet.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { Prisma } from '@prisma/client';
 import type { Meet, MeetType } from '@prisma/client';
 import prisma from '@/lib/prisma';
 import { getCurrentUser } from '@/lib/authentication';
@@ -83,7 +84,15 @@ export async function createMeet(args: CreateMeetArguments): Promise<Meet> {
   }
 }
 
-export async function getMeet(meetId: string): Promise<Meet> {
+const meetWithParticipants = Prisma.validator<Prisma.MeetDefaultArgs>()({
+  include: { participants: true },
+});
+
+export type MeetWithParticipants = Prisma.MeetGetPayload<
+  typeof meetWithParticipants
+>;
+
+export async function getMeet(meetId: string): Promise<MeetWithParticipants> {
   try {
     const currentUser = await getCurrentUser();
     const meet = await prisma.meet.findUniqueOrThrow({


### PR DESCRIPTION
## 변경사항

- MeetWithParticipants type (참고글: https://www.prisma.io/docs/orm/prisma-client/type-safety/operating-against-partial-structures-of-model-types#solution)
- `getMeet` return type update: Promise<Meet> -> Promise<MeetWithParticipants>