### PR TITLE
fix: interaction with localStorage

### DIFF
--- a/src/app/(main)/create/page.tsx
+++ b/src/app/(main)/create/page.tsx
@@ -8,15 +8,15 @@ export default function CreatePage() {
   const router = useRouter();
   const hours = Array.from({ length: 24 }, (_, index) => index + 1);
   const mins = [0, 30];
+
+  // extract data from localStorage
+  const selection = localStorage.getItem('selection');
   useEffect(() => {
-    // extract data from localStorage
-    const selection = localStorage.getItem('selection');
     if (!selection) {
       alert('No selection');
       router.push('/');
     } else {
-      const { mode: meetingMode, selections: meetingSelections } =
-        JSON.parse(selection);
+      const { mode, selections } = JSON.parse(selection);
       localStorage.removeItem('selection'); // remove once it's read
 
       // set mode and selections to form
@@ -24,13 +24,13 @@ export default function CreatePage() {
         'input[name="meetingMode"]'
       );
       if (modeInput) {
-        modeInput.value = meetingMode;
+        modeInput.value = mode;
       }
       const selectionsInput = document.querySelector<HTMLInputElement>(
         'input[name="meetingSelections"]'
       );
       if (selectionsInput) {
-        selectionsInput.value = meetingSelections;
+        selectionsInput.value = selections;
       }
     }
   });
@@ -41,8 +41,8 @@ export default function CreatePage() {
         action={handleSubmit}
         className="grid text-white place-items-center"
       >
-        <input type="hidden" name="meetingMode"></input>
-        <input type="hidden" name="meetingSelections"></input>
+        <input type="hidden" readOnly name="meetingMode"></input>
+        <input type="hidden" readOnly name="meetingSelections"></input>
         <div className="grid-1 w-[301px] h-[40px] border-b-2 mt-3 ">
           <input
             id="meetingName"
@@ -118,7 +118,7 @@ export default function CreatePage() {
                 type="date"
                 id="scheduleEndDate"
                 name="scheduleEndDate"
-                value={new Date().toISOString().split('T')[0]}
+                defaultValue={new Date().toISOString().split('T')[0]}
                 className="bg-[#3C3F45] rounded-md text-[#20ECC7]"
               />
             </div>


### PR DESCRIPTION
## 변경사항

### 벌레 퇴치

```TypeScript
  useEffect(() => {
    const selection = localStorage.getItem('selection');
    if (!selection) {
      alert('No selection');
      router.push('/');
    } else {
      const { mode, selections } = JSON.parse(selection);
      // ...
    }
```
이랬던 코드를...

```TypeScript
  const selection = localStorage.getItem('selection'); // useEffect 앞으로 옮겼어요!
  useEffect(() => {
    if (!selection) {
      alert('No selection');
      router.push('/');
    } else {
      const { mode, selections } = JSON.parse(selection);
      // ...
    }
```
이렇게 바꿨습니다!

useEffect 내의 함수가 두 번 호출되는데(다시 보니 이에 대한 공부가 부족하네요. 이를 추후 확인해보도록 하겠습니다.), 전자의 경우 `selection` 변수가 `null`이 되어버립니다. 하지만 후자의 경우는 그렇지 않게 되어 정상적으로 작동합니다.

### input tag 경고 메시지 제거 

- 기존에 다음과 같은 에러 메시지를 콘솔에서 확인했습니다: ```You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`.```

- hidden input tag의 경우 `readOnly` property를 추가했습니다.
- 그 외에 input tag 중 기본값을 줘야하는 것에 value 대신 defaultValue로 기본 값을 제공했습니다.